### PR TITLE
Changing title on zone switch - feature added

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -11,6 +11,9 @@ namespace TitleRoulette
 
         #region Saved configuration values
         public Dictionary<ulong, List<TitleGroup>> TitleGroups { get; set; } = new();
+
+        public bool       assignRandomTitleOnAreaChange { get; set; }
+        public TitleGroup randomTitleGroup              { get; set; }
         #endregion
 
         public List<TitleGroup> GetCurrentCharacterGroups()

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -23,8 +23,9 @@ namespace TitleRoulette
             }
 
             Service.PluginInterface.UiBuilder.OpenConfigUi += OpenConfigWindow;
-            Service.PluginInterface.UiBuilder.Draw += Service.WindowSystem.Draw;
-            Service.PluginCommandManager = new PluginCommandManager<Plugin>(this, Service.CommandManager);
+            Service.PluginInterface.UiBuilder.Draw         += Service.WindowSystem.Draw;
+            Service.PluginCommandManager                   =  new PluginCommandManager<Plugin>(this, Service.CommandManager);
+            Service.ClientState.TerritoryChanged           += (_, _) => RandomTitleEvent();
         }
 
         private void InitializeTitles()
@@ -37,6 +38,11 @@ namespace TitleRoulette
                 Service.Titles.Add(new Title { Id = (ushort)title.RowId, MasculineName = title.Masculine, FeminineName = title.Feminine, IsPrefix = title.IsPrefix });
             }
             Service.MaxTitleId = Service.Titles.Max(x => x.Id);
+        }
+
+        private void RandomTitleEvent()
+        {
+            SetRandomTitleFromGroup(Service.Configuration.randomTitleGroup);
         }
 
         [Command("/ptitle")]
@@ -53,11 +59,15 @@ namespace TitleRoulette
                 Service.Chat.PrintError($"[Title Roulette] Group '{args}' does not exist.");
                 return;
             }
+            SetRandomTitleFromGroup(group);
+        }
 
+        public void SetRandomTitleFromGroup(Configuration.TitleGroup group)
+        {
             int titleCount = group.Titles.Count;
             if (titleCount == 0)
             {
-                Service.Chat.PrintError($"[Title Roulette] Can't pick a random title from group '{args}' as it is empty.");
+                Service.Chat.PrintError($"[Title Roulette] Can't pick a random title from group '{group.Name}' as it is empty.");
                 return;
             }
 

--- a/PluginWindow.cs
+++ b/PluginWindow.cs
@@ -147,7 +147,8 @@ namespace TitleRoulette
 
         public class TitleSelection
         {
-            private int currentGroup = 0;
+            private int currentGroup          = 0;
+            private int currentGroupForRandom = 0;
 
             public required List<Configuration.TitleGroup> Groups { get; set; }
             public required List<Title> SortedTitles { get; set; }
@@ -255,6 +256,28 @@ namespace TitleRoulette
                 ImGui.EndDisabled();
                 if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled) && !ImGui.GetIO().KeyCtrl)
                     ImGui.SetTooltip("Hold CTRL to discard any changes you've made since you've last saved.");
+                ImGui.SameLine();
+                bool randomAssign = Service.Configuration.assignRandomTitleOnAreaChange;
+                ImGui.Checkbox("Random title when switching Zones", ref randomAssign);
+                Service.Configuration.assignRandomTitleOnAreaChange = randomAssign;
+
+                if (randomAssign)
+                {
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(200);
+                    if (ImGui.BeginCombo("###GroupComboRandom", $"{Groups[currentGroupForRandom].Name} ({FormatTitleCount(Groups[currentGroupForRandom])})"))
+                    {
+                        for (int i = 0; i < Groups.Count; ++i)
+                        {
+                            if (ImGui.Selectable($"{Groups[i].Name} ({FormatTitleCount(Groups[i])})", i == currentGroupForRandom))
+                            {
+                                currentGroupForRandom                  = i;
+                                Service.Configuration.randomTitleGroup = Groups[currentGroupForRandom];
+                            }
+                        }
+                        ImGui.EndCombo();
+                    }
+                }
 
                 if (save)
                 {


### PR DESCRIPTION
Title Roulette is a great plugin and it works nicely, but I would love for it to roll the roulette on its own.

If enabled, on ClientState.TerritoryChanged it will randomly pick a title from the configured title group and apply it.
Config is at the moment placed at the bottom of the config window, next to the save buttons.

Tested it for a few hours today and haven't run into any issues with it, 
although there might be cases I'm not thinking of.